### PR TITLE
Improved to work even if number of GloVe vectors is less than num_words

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -31,6 +31,7 @@ def build_word_vector_matrix(vector_file, n_words):
 			np_arrays.append(np.array([float(j) for j in sr[1:]]))
 			if i == n_words - 1:
 				return np.array(np_arrays), labels_array
+		return np.array(np_arrays), labels_array
 
 def get_cache_filename_from_args(args):
         a = (args.vector_dim, args.num_words, args.num_clusters)


### PR DESCRIPTION
For the cases in which the number of lines in GloVe vectors file was below num_words argument, an error like this was produced:

```
Traceback (most recent call last):
  File "word_clustering.py", line 66, in <module>
    df, labels_array = build_word_vector_matrix(vector_file, args.num_words)
TypeError: 'NoneType' object is not iterable
```

It is more likely when the size of the dataset is small or a large number is specified for the num_words arguments in the command line